### PR TITLE
Turned issuer validation off.

### DIFF
--- a/node-server/config.js
+++ b/node-server/config.js
@@ -11,7 +11,7 @@ exports.creds = {
 
   // Required.
   // If you are using the common endpoint, you should either set `validateIssuer` to false, or provide a value for `issuer`.
-  validateIssuer: true,
+  validateIssuer: false,
 
   // Required. 
   // Set to true if you use `function(req, token, done)` as the verify callback.


### PR DESCRIPTION
Having validateIssuer turned on by default in the example is a good thing since it is closer to a real scenario, but it led to a lot of problems when I was testing this out. 

The metadata from the tenant-specific endpoint suggested the token should be from:
`https://login.microsoftonline.com/<tenant GUID>/v2.0`

The metadata obtained by decoding the token reports the it was issued from:
`https://sts.windows.net/<tenant GUID>/`

Changing the "issuer" field to expect "sts.windows.../" with the tenant address "___.onmicrosoft.com" still led the API to reject the token. Only with the tenant GUID was I able to successfully authenticate a request.

Since users should ideally not need to know about the token format, token issuers nor the tenant GUID, I propose the simplest change is to not check the issuer. This is also consistent with the v2 .NET Web API [sample](https://github.com/AzureADQuickStarts/AppModelv2-WebAPI-DotNet/blob/complete/TodoListService/App_Start/Startup.Auth.cs#L33).