### PR TITLE
fix: changes 'req' to 'token' in comment to avoid confusion

### DIFF
--- a/node-server/config.js
+++ b/node-server/config.js
@@ -15,7 +15,7 @@ exports.creds = {
 
   // Required. 
   // Set to true if you use `function(req, token, done)` as the verify callback.
-  // Set to false if you use `function(req, token)` as the verify callback.
+  // Set to false if you use `function(token, done)` as the verify callback.
   passReqToCallback: false,
 
   // Required if you are using common endpoint and setting `validateIssuer` to true.


### PR DESCRIPTION
The comment it about how the 'req' property will be passed to the callback if you set `passReqToCallback` to `true`. The comment said that you'd get `req, token` even if it was false. I've updated it so that it says `token, done`, since you will not receive `req` if it is set to false.